### PR TITLE
Fix allow_data_uri on img tag breaking regular url

### DIFF
--- a/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
+++ b/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
@@ -38,7 +38,7 @@ class ImgSrcSanitizer
 
         if ($this->allowDataUri) {
             $allowedSchemes[] = 'data';
-            $allowedHosts[] = null;
+            $allowedHosts = null;
         }
 
         if (!$sanitized = $this->sanitizeUrl($input, $allowedSchemes, $allowedHosts, $this->forceHttps)) {

--- a/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
+++ b/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
@@ -38,7 +38,9 @@ class ImgSrcSanitizer
 
         if ($this->allowDataUri) {
             $allowedSchemes[] = 'data';
-            $allowedHosts = null;
+            if (null !== $allowedHosts) {
+                $allowedHosts[] = null;
+            }
         }
 
         if (!$sanitized = $this->sanitizeUrl($input, $allowedSchemes, $allowedHosts, $this->forceHttps)) {


### PR DESCRIPTION
When allow_data_uri is set to true and allowed_hosts is kept at null the latter is converted to [null] which disallows all urls